### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release Build
 
+permissions:
+  contents: write
+  packages: read
+  actions: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/nico-swan-com/git-project-updater/security/code-scanning/2](https://github.com/nico-swan-com/git-project-updater/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions:
- `contents: read` is needed for accessing the repository's contents.
- `packages: read` is required for using Cachix.
- `actions: read` is needed for downloading artifacts.
- `contents: write` is required for creating releases and uploading release assets.

The `permissions` block will be added at the workflow level to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for GitHub Actions to explicitly define access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->