### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   build-and-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -97,6 +99,8 @@ jobs:
 
   # Create a GitHub Release if it doesn't exist for the tag
   create_release:
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/nico-swan-com/git-project-updater/security/code-scanning/1](https://github.com/nico-swan-com/git-project-updater/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimum required permissions. Based on the workflow's functionality:
1. The `build-and-release` job requires `contents: read` to check out the repository and `contents: write` to upload release assets.
2. The `create_release` job requires `contents: read` to access the repository and `contents: write` to create a release.

We will add a `permissions` block at the job level for both `build-and-release` and `create_release` jobs to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow configuration to ensure proper permissions for release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->